### PR TITLE
Forcing loss of focus on input when an item is selected

### DIFF
--- a/d2l-autocomplete.js
+++ b/d2l-autocomplete.js
@@ -313,7 +313,9 @@ class Autocomplete extends PolymerElement {
 		this._dropdownIndex = -1;
 		this._input.value = selection;
 		this._filter = '';
+		this._inputHasFocus = false;
 
+		this._updateSuggestionsVisible();
 		this.dispatchEvent(new CustomEvent(
 			'd2l-autocomplete-suggestion-selected',
 			{ bubbles: true, composed: true, detail: { value: selection } }


### PR DESCRIPTION
When show-on-focus is enabled, there's a delay between the click and when the dropdown disappears. The dropdown also wouldn't disappear when min-length = 0. This should resolve both of those issues.