### PR TITLE
fixing 2-way binding that doesn't work with Lit

### DIFF
--- a/d2l-autocomplete-input-text.js
+++ b/d2l-autocomplete-input-text.js
@@ -25,7 +25,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-autocomplete-input-text">
 			aria-label$="[[ariaLabel]]"
 			id="[[_prefix('d2l-input-text')]]"
 			maxlength="[[maxLength]]"
-			on-change="_handleChange"
+			on-input="_handleInput"
 			placeholder$="[[placeholder]]"
 			role="combobox"
 			slot="input"
@@ -98,7 +98,7 @@ class AutocompleteInputText extends PolymerElement {
 		this._uniqueId = D2L.Id.getUniqueId();
 	}
 
-	_handleChange(e) {
+	_handleInput(e) {
 		this.value = e.target.value;
 	}
 

--- a/d2l-autocomplete-input-text.js
+++ b/d2l-autocomplete-input-text.js
@@ -17,6 +17,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-autocomplete-input-text">
 			data="[[data]]"
 			id="[[_prefix('d2l-autocomplete')]]"
 			min-length="[[minLength]]"
+			on-d2l-autocomplete-suggestion-selected="_handleSuggestionSelected"
 			remote-source="[[remoteSource]]"
 			select-first="[[selectFirst]]"
 			show-on-focus="[[showOnFocus]]"
@@ -24,11 +25,12 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-autocomplete-input-text">
 			aria-label$="[[ariaLabel]]"
 			id="[[_prefix('d2l-input-text')]]"
 			maxlength="[[maxLength]]"
+			on-change="_handleChange"
 			placeholder$="[[placeholder]]"
 			role="combobox"
 			slot="input"
 			type$="[[type]]"
-			value="{{value}}">
+			value="[[value]]">
 		</d2l-input-text>
 		</d2l-autocomplete>
 	</template>
@@ -94,6 +96,14 @@ class AutocompleteInputText extends PolymerElement {
 	constructor() {
 		super();
 		this._uniqueId = D2L.Id.getUniqueId();
+	}
+
+	_handleChange(e) {
+		this.value = e.target.value;
+	}
+
+	_handleSuggestionSelected(e) {
+		this.value = e.detail.value;
 	}
 
 	_prefix(id) {


### PR DESCRIPTION
The problem here is that when we upgraded `<d2l-input-text>` to Lit, we didn't realize that places relying on 2-way binding (like this one) would stop working.

I don't think anyone was actually relying on the `value` property of `d2l-autocomplete-input-text`, since typically they'd wire up to autocomplete's `d2l-autocomplete-suggestion-selected` event. In fact, the only usage of this component I could find [doesn't use the value, but the event](https://github.com/Brightspace/publish-fra/blob/f0d9d8a793bbcf76afa403ceefcb6db63113cdb1/src/components/recipient-selector.js#L61), so should be fine.

This PR replaces the 2-way binding with a 1-way and syncs the property using events. It's not quite as simple as just listening to the `input` event on the input though, since a selection from the autocomplete dropdown sets the input's `value` directly, which doesn't fire the event. So we need to listen for both.